### PR TITLE
Add test coverage reporting / coveralls.io integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: go
 
 go:
-  - 1.6
+  - 1.7
 
 install:
   - ./install.sh
+  - go get golang.org/x/tools/cmd/cover
+  - go get github.com/mattn/goveralls
+
+env:
+  global:
+    secure: fd5fDwogzZNt8ZlYnS/c7X1L3DQYxxyf+JiKLz6IZDrNFsyj60iEbcqECsNgvAHPvuFA+w2oSquFikCb7uaOhwedCJEfcyzl3sYN4vuLYyJJ1GH5S97s+DJnpR9gZfnBtAGjutg3RxexZz0T+B/wFcVDnJ3cg4DopyPKvmJv3XALMw6pR0NffE+qucckEHVZtchuTNI67W/q5NkRtPPNfrT185UH2TpI060kx/uxuYEIFEsKQCWKiYZwPu2qpgTQTiKmJOlcJ084KdYM0r8GelmQUeuPvtgiZwsi0scitjBVjKeBP/gPVoUimCbAMyF0Pj26oSXa3QSaybazoZVGlG7PuGfI9mHqpaaI5n9mPM8Tzb3QNTVBDDj1VLgbz4MomP573Ofctp+uGtZJt1AQgvLg1JXPTt34JUM2IL3yZaw4z+P1vTlAoNevKaxmFir5vUedB7Pz6BNJItTKhYexX4Y/SBVK3AN82gOtRn8u8AUzpOMdDxHX3mK3MoSqqGVUCLAUR8SijePR2sc5qV78Ji9TpQx40vFTXBGJgiVKko83UQXKpNXxzmshxmFs/SpayeyjIsIMTrOdbx9gh60mlnKLgwsd2tOhNsqt8F1vzW5RB0iRk8IIhfnVMemtRtUyMZlOCZBWR1Ap5vOS2FwxgUk7hqrEwl6ujEQaJX1zJ0g=
 
 script:
   - make test

--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,9 @@ test_lint:
 test_verbose:
 	go test -v -race -short ./...
 
+# use test_verbose instead if you want to use this Makefile locally
 test_go:
-	go test -race -short ./...
+	./coveralls.sh
 
 test: test_fmt test_lint test_go
 

--- a/coveralls.sh
+++ b/coveralls.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Source: https://github.com/h12w/gosweep/blob/master/gosweep.sh
+
+DIR_SOURCE="$(find . -maxdepth 10 -type f -not -path '*/vendor*' -name '*.go' | xargs -I {} dirname {} | sort | uniq)"
+
+# Run test coverage on each subdirectories and merge the coverage profile.
+
+echo "mode: atomic" > profile.cov
+
+for dir in ${DIR_SOURCE};
+do
+    go test -short -race -covermode=atomic -coverprofile=$dir/profile.tmp $dir
+    if [ -f $dir/profile.tmp ]
+    then
+        cat $dir/profile.tmp | tail -n +2 >> profile.cov
+        rm $dir/profile.tmp
+    fi
+done
+
+# If you want to print the coverage of each file individually uncomment:
+# go tool cover -func profile.cov
+
+# To submit the test coverage result to coveralls.io,
+# use goveralls (https://github.com/mattn/goveralls)
+goveralls -coverprofile=profile.cov -service=travis-ci -repotoken $COVERALLS_TOKEN


### PR DESCRIPTION
- add coveralls integration (exactly like for the cothority repo)
- switch to go 1.7 while we're at it
- resolves #56
